### PR TITLE
scm fixes

### DIFF
--- a/Main/Commercial/yard1.sc
+++ b/Main/Commercial/yard1.sc
@@ -251,7 +251,7 @@ counter_joint_placing = 0
 ADD_BLIP_FOR_COORD start_x start_y -100.0 blip_start_yd1
 
 flag_leader = 0
-flag_random_yd1 = 0
+//flag_random_yd1 = 0  // SCFIX: initialized later in GENERATE ROUTE FLAG
 
 REQUEST_MODEL PED_MALE2
 REQUEST_MODEL CAR_PATRIOT
@@ -418,6 +418,8 @@ SET_PED_DENSITY_MULTIPLIER 1.0
 
 //----------------GENERATE ROUTE FLAG--------------------------------------------
 
+// SCFIX: START
+/*
 GENERATE_RANDOM_INT random_yd1
 
 IF random_yd1 > 21845
@@ -428,6 +430,11 @@ ENDIF
 IF random_yd1 > 43690
 	flag_random_yd1 = 2
 ENDIF
+*/
+
+GENERATE_RANDOM_INT 0 3 flag_random_yd1
+
+// SCFIX: END
 
 //-----------TURN OFF TUNNEL NODES-------------------------
 

--- a/Main/Commercial/yard1.sc
+++ b/Main/Commercial/yard1.sc
@@ -432,7 +432,7 @@ IF random_yd1 > 43690
 ENDIF
 */
 
-GENERATE_RANDOM_INT 0 3 flag_random_yd1
+GENERATE_RANDOM_INT_IN_RANGE 0 3 flag_random_yd1
 
 // SCFIX: END
 

--- a/Main/Industrial/hj.sc
+++ b/Main/Industrial/hj.sc
@@ -246,7 +246,7 @@ IF flag_takeoff_hj = 1
 	REGISTER_JUMP_SPINS total_rotation_int
 ENDIF
 
-IF height_int_hj > 4	   	//4 METERS HIGH  // SCFIX: was 4.0
+IF height_int_hj > 4	   	//4 METERS HIGH  // SCFIX: was height_float_hj > 4.0
 	++ stunt_flags_hj
 ENDIF
 

--- a/Main/Industrial/hj.sc
+++ b/Main/Industrial/hj.sc
@@ -246,7 +246,7 @@ IF flag_takeoff_hj = 1
 	REGISTER_JUMP_SPINS total_rotation_int
 ENDIF
 
-IF height_float_hj > 4.0	   	//4 METERS HIGH
+IF height_float_hj > 4	   	//4 METERS HIGH  // SCFIX: was 4.0
 	++ stunt_flags_hj
 ENDIF
 

--- a/Main/Industrial/hj.sc
+++ b/Main/Industrial/hj.sc
@@ -246,7 +246,7 @@ IF flag_takeoff_hj = 1
 	REGISTER_JUMP_SPINS total_rotation_int
 ENDIF
 
-IF height_float_hj > 4	   	//4 METERS HIGH  // SCFIX: was 4.0
+IF height_int_hj > 4	   	//4 METERS HIGH  // SCFIX: was 4.0
 	++ stunt_flags_hj
 ENDIF
 


### PR DESCRIPTION
Fixes 2 bugs:

1. Quadruple Insane Stunt bonus was impossible to get, because they used a float value instead of an int
2. Bling-Bling Scramble is supposed to have 3 checkpoint patterns and that works on PS2. However, on PC you can only get the first 2, because the random number generator is capped at a lower value (32768, I think). The way I fixed it makes the `random_yd1` variable unused, but I didn't remove its declaration

I also didn't touch README.md, I assume you add changes there once they get in a release