### PR TITLE
Debug and pickups

### DIFF
--- a/Main/Commercial/asuka5.sc
+++ b/Main/Commercial/asuka5.sc
@@ -232,7 +232,7 @@ SET_CHAR_OBJ_RUN_TO_COORD tanner 435.7 -1388.8
 			ENDIF
 
 			IF TIMERB > 10000
-				IF NOT IS_CHAR_DEAD	lips
+				IF NOT IS_CHAR_DEAD	tanner // SCFIX: was 'lips'
 					SET_CHAR_COORDINATES tanner 435.7 -1388.8 -100.0
 				ENDIF
 			ENDIF
@@ -254,8 +254,8 @@ SET_CHAR_OBJ_RUN_TO_COORD tanner 423.5 -1388.8
 			ENDIF
 
 			IF TIMERB > 10000
-				IF NOT IS_CHAR_DEAD	lips
-					SET_CHAR_COORDINATES tanner 427.3 -1388.6 25.0
+				IF NOT IS_CHAR_DEAD	tanner // SCFIX: was 'lips'
+					SET_CHAR_COORDINATES tanner 423.5 -1388.8 25.0 // SCFIX: fixed coordinates
 				ENDIF
 			ENDIF
 
@@ -276,7 +276,7 @@ SET_CHAR_OBJ_RUN_TO_COORD tanner 423.6 -1393.1
 			ENDIF
 
 			IF TIMERB > 10000
-				IF NOT IS_CHAR_DEAD	lips
+				IF NOT IS_CHAR_DEAD	tanner // SCFIX: was 'lips'
 					SET_CHAR_COORDINATES tanner 423.6 -1393.1 25.0
 				ENDIF
 			ENDIF

--- a/Main/Industrial/genstuf.sc
+++ b/Main/Industrial/genstuf.sc
@@ -88,11 +88,18 @@ check_info_pickup:
 {
 
 LVAR_INT pickup message_num
+LVAR_INT end_when_industrial_passed // SCFIX: Added
 
 start_pickup_script:
 
 WHILE NOT HAS_PICKUP_BEEN_COLLECTED pickup
 	WAIT 500
+	// SCFIX: START
+	IF end_when_industrial_passed = 1
+	AND flag_industrial_passed = 1
+		TERMINATE_THIS_SCRIPT
+	ENDIF
+	// SCFIX: END
 ENDWHILE
 
 IF message_num = 1
@@ -148,11 +155,18 @@ check_info_pickup_2:
 {
 
 LVAR_INT pickup message_num
+LVAR_INT end_when_industrial_passed // SCFIX: Added
 
 start_pickup_script_2:
 
 WHILE NOT HAS_PICKUP_BEEN_COLLECTED pickup
 	WAIT 500
+	// SCFIX: START
+	IF end_when_industrial_passed = 1
+	AND flag_industrial_passed = 1
+		TERMINATE_THIS_SCRIPT
+	ENDIF
+	// SCFIX: END
 ENDWHILE
 
 GET_CONTROLLER_MODE controlmode

--- a/Main/Industrial/pickups.sc
+++ b/Main/Industrial/pickups.sc
@@ -201,26 +201,26 @@ heal_info_trip = 0
 wanted_info_trip = 0
 
 CREATE_PICKUP info PICKUP_ON_STREET 921.3 -352.8 10.9 info_pickup1 //Spary shop
-START_NEW_SCRIPT check_info_pickup info_pickup1 1
+START_NEW_SCRIPT check_info_pickup info_pickup1 1 1 // SCFIX: Extra parameter added
 
 CREATE_PICKUP info PICKUP_ON_STREET 1279.5 -98.3 15.0 info_pickup2 //Bomb shop
 START_NEW_SCRIPT check_info_pickup info_pickup2	2
 CREATE_PICKUP info PICKUP_ON_STREET 1065.0 -392.8 14.9 info_pickup3	//Ammu nation
-START_NEW_SCRIPT check_info_pickup info_pickup3	3
+START_NEW_SCRIPT check_info_pickup info_pickup3	3 1 // SCFIX: Extra parameter added
 CREATE_PICKUP info PICKUP_ON_STREET 889.5 -316.1 8.7 info_pickup4 //Save garage 
-START_NEW_SCRIPT check_info_pickup info_pickup4	4
+START_NEW_SCRIPT check_info_pickup info_pickup4	4 1 // SCFIX: Extra parameter added
 CREATE_PICKUP info PICKUP_ON_STREET 889.5 -305.8 8.7 info_pickup5 //Save house
-START_NEW_SCRIPT check_info_pickup info_pickup5 5
+START_NEW_SCRIPT check_info_pickup info_pickup5 5 1 // SCFIX: Extra parameter added
 CREATE_PICKUP info PICKUP_ON_STREET 1130.4 52.8 0.4 info_pickup6 //Crusher
 START_NEW_SCRIPT check_info_pickup info_pickup6 6
 CREATE_PICKUP info PICKUP_ON_STREET 1028.8 -927.4 15.0 info_pickup7a //Callahan Bridge
-START_NEW_SCRIPT check_info_pickup_2 info_pickup7a 7
+START_NEW_SCRIPT check_info_pickup_2 info_pickup7a 7 1 // SCFIX: Extra parameter added
 CREATE_PICKUP info PICKUP_ON_STREET 916.5 -472.0 -18.8 info_pickup7b //SUBWAY
 START_NEW_SCRIPT check_info_pickup_2 info_pickup7b 11
 CREATE_PICKUP info PICKUP_ON_STREET 758.7 164.2 -19.9 info_pickup8 //Porter Tunnel 
-START_NEW_SCRIPT check_info_pickup_2 info_pickup8	8
+START_NEW_SCRIPT check_info_pickup_2 info_pickup8	8 1 // SCFIX: Extra parameter added
 CREATE_PICKUP info PICKUP_ON_STREET 991.9 -471.3 3.7 info_pickup9 //Tube -industrial
-START_NEW_SCRIPT check_info_pickup_2 info_pickup9 9
+START_NEW_SCRIPT check_info_pickup_2 info_pickup9 9 1 // SCFIX: Extra parameter added
 CREATE_PICKUP info PICKUP_ON_STREET 1318.7 -524.9 43.3 info_pickup10a //A-trains
 START_NEW_SCRIPT check_info_pickup_2 info_pickup10a 10
 CREATE_PICKUP info PICKUP_ON_STREET 772.0 -588.4 23.9 info_pickup10b //A-trains

--- a/main_d.sc
+++ b/main_d.sc
@@ -2746,21 +2746,21 @@ ENDIF
 	AND flag_eightball_mission_launched = 0
 	AND flag_player_on_mission = 0
 		IF flag_reached_hideout = 0								    
-			//IF LOCATE_PLAYER_ON_FOOT_2D player 811.90 -939.95 3.5 3.5 FALSE // SCFIX: commented
+			IF LOCATE_PLAYER_ON_FOOT_2D player 811.90 -939.95 3.5 3.5 FALSE // SCFIX: commented out in main.sc, but main_d.sc needs it
 				IF CAN_PLAYER_START_MISSION Player
 					flag_player_on_mission = 1 // SCFIX
 					LOAD_AND_LAUNCH_MISSION 8ball.sc	//	Don't know what to do about fades with this one
 					flag_eightball_mission_launched = 1
 				ENDIF
-			//ENDIF // SCFIX: commented
+			ENDIF // SCFIX: commented out in main.sc, but main_d.sc needs it
 		ELSE
-			//IF LOCATE_PLAYER_ON_FOOT_2D player 883.5 -308.2 3.5 3.5 FALSE  // SCFIX: commented
+			IF LOCATE_PLAYER_ON_FOOT_2D player 883.5 -308.2 3.5 3.5 FALSE  // SCFIX: commented
 				IF CAN_PLAYER_START_MISSION Player
 					flag_player_on_mission = 1 // SCFIX
 					LOAD_AND_LAUNCH_MISSION 8ball.sc	//	Don't know what to do about fades with this one
 					flag_eightball_mission_launched = 1
 				ENDIF
-			//ENDIF // SCFIX: commented
+			ENDIF // SCFIX: commented out in main.sc, but main_d.sc needs it
 		ENDIF 
 	ENDIF
    


### PR DESCRIPTION
* main_d: Fix Give me Liberty auto-starting from the debug menu. main_d needs one of the SCFIX fixes removed, so debug mission triggers still work correctly.
* genstuf: Terminate pickup scripts for pickups that despawn. revents a tiny chance of a pickup handle conflict after finishing Portland despawns some info pickups, but their scripts continue running.