### PR TITLE
Fixes for "Cipriani's Chauffeur" (`joey4`) for "Dead Skunk in the Trunk" (`joey5`)

### DIFF
--- a/Main/Industrial/joey4.sc
+++ b/Main/Industrial/joey4.sc
@@ -27,7 +27,7 @@ VAR_INT blip1_jm4 blip2_jm4 blip3_jm4 flag_car_blip_displayed_jm4 triads_ojectiv
 
 VAR_INT ojective_triad1_done_before ojective_triad2_done_before
 
-VAR_INT Toni_abuse1_done_before	tonis_car_created_before played_tune_before
+VAR_INT Toni_abuse1_done_before	/*tonis_car_created_before*/ played_tune_before // SCFIX - variable cut
 
 VAR_INT flag_displayed_wanted_message_jm4 flag_displayed_horn_message_jm4
 
@@ -48,9 +48,11 @@ flag_player_on_joey_mission = 1
 SCRIPT_NAME joey4
 WAIT 0
 
+/* SCFIX - cut, this is unsafe and may be operating on stale handles
 IF tonis_car_created_before = 1
 	GOSUB delete_tonis_car
 ENDIF
+*/
 
 flag_displayed_wanted_message_jm4 = 0
 flag_displayed_horn_message_jm4 = 0
@@ -86,7 +88,7 @@ OR NOT HAS_MODEL_LOADED CAR_STALLION
 ENDWHILE
 
 CREATE_CAR CAR_MAFIA 1189.72 -864.28 14.1 tonis_ride
-tonis_car_created_before = 1
+//tonis_car_created_before = 1 // SCFIX - cut
 SET_CAR_HEADING tonis_ride -142.0
 SET_RADIO_CHANNEL 1 -1
 
@@ -277,10 +279,17 @@ CLEAR_AREA 1198.5 -871.4 15.0 10.0 TRUE
 SET_FIXED_CAMERA_POSITION 1200.831 -869.373 15.001 0.0 0.0 0.0
 POINT_CAMERA_AT_POINT 1199.887 -869.701 15.025 JUMP_CUT
 
+/* SCFIX - moved the wait to fix a 1-frame window where the player could leave the car
 WAIT 0
 SWITCH_WIDESCREEN ON
+*/
 SET_POLICE_IGNORE_PLAYER Player ON
 SET_PLAYER_CONTROL Player OFF
+
+// SCFIX: START - moved the wait to fix a 1-frame window where the player could leave the car
+WAIT 0
+SWITCH_WIDESCREEN ON
+// SCFIX: END
 
 //WAIT 500
 
@@ -321,6 +330,8 @@ IF NOT IS_CHAR_DEAD toni
 	PLAYER_LOOK_AT_CHAR_ALWAYS player toni
 	//SET_ANIM_GROUP_FOR_CHAR toni ANIM_OLDFAT_PED
 ENDIF
+
+TIMERB = 0 // SCFIX - added a timeout to the cutscene
 
 WHILE NOT LOCATE_CAR_2D tonis_ride 1198.5 -871.4 2.0 2.0 FALSE
 	WAIT 0
@@ -372,6 +383,14 @@ WHILE NOT LOCATE_CAR_2D tonis_ride 1198.5 -871.4 2.0 2.0 FALSE
 		LOAD_MISSION_AUDIO J4T_3
 
 		tonis_audio_all_finished = 1
+		// SCFIX: START - added a timeout to the cutscene
+	ELSE
+		IF TIMERB > 10000
+			CLEAR_AREA 1198.5 -871.4 15.0 10.0 TRUE
+			SET_CAR_COORDINATES tonis_ride 1198.5 -871.4 14.1
+			SET_CAR_HEADING tonis_ride -127.0
+		ENDIF
+		// SCFIX: END
 	ENDIF
 	
 
@@ -505,6 +524,7 @@ flag_car_blip_displayed_jm4 = TRUE
 blob_flag = 1
 
 	IF IS_CAR_DEAD tonis_ride
+	OR IS_CHAR_DEAD toni // SCFIX: added check
 		PRINT_NOW ( JM4_8 ) 5000 1
 		GOTO mission_joey4_failed
 	ENDIF
@@ -516,6 +536,7 @@ blob_flag = 1
 		WAIT 0
 
 		IF IS_CAR_DEAD tonis_ride
+		OR IS_CHAR_DEAD toni // SCFIX: added check
 			PRINT_NOW ( JM4_8 ) 5000 1
 			GOTO mission_joey4_failed
 		ENDIF
@@ -551,6 +572,15 @@ blob_flag = 1
 			PLAY_MISSION_AUDIO
 			Toni_abuse1_done_before = 1
 		ENDIF	
+
+		// SCFIX: START - stop Toni's line if he's hurt
+		IF NOT IS_CHAR_HEALTH_GREATER toni 1
+		AND Toni_abuse1_done_before = 1
+			CLEAR_THIS_PRINT JM4_6
+			CLEAR_MISSION_AUDIO
+			Toni_abuse1_done_before = 2
+		ENDIF
+		// SCFIX: END
 
 		IF IS_PLAYER_STOPPED_IN_AREA_IN_CAR_3D player 839.2 -667.4 14.0 842.1 -673.9 17.0 FALSE
 
@@ -1306,6 +1336,7 @@ MISSION_HAS_FINISHED
 RETURN
 
 
+/* SCFIX - cut, this is unsafe and may be operating on stale handles
 {
 delete_tonis_car:
 
@@ -1313,3 +1344,4 @@ delete_tonis_car:
 
 RETURN
 }
+*/

--- a/Main/Industrial/joey5.sc
+++ b/Main/Industrial/joey5.sc
@@ -248,6 +248,7 @@ SET_CAR_ONLY_DAMAGED_BY_PLAYER lipsbrother2_car TRUE
    			GOTO mission_joey5_failed
    		ENDIF
 
+		/* SCFIX - rewritten with extra chase triggers
 		IF IS_CHAR_DEAD lipsbrother1
 		AND is_lipsbrother1_car_dead = 0
 			ADD_SCORE player 5000 
@@ -273,6 +274,49 @@ SET_CAR_ONLY_DAMAGED_BY_PLAYER lipsbrother2_car TRUE
 				GOTO kill_the_player
 			ENDIF
 		ENDIF
+		*/
+
+		// SCFIX: START - rewritten with extra chase triggers
+		IF IS_CHAR_DEAD lipsbrother1
+			IF is_lipsbrother1_car_dead = 0
+				ADD_SCORE player 5000 
+				is_lipsbrother1_car_dead = 1
+			ENDIF
+			GOTO kill_the_player_display_message
+		ELSE
+			IF NOT IS_CHAR_HEALTH_GREATER lipsbrother1 99
+				GOTO kill_the_player_display_message
+			ENDIF
+		ENDIF
+
+		IF IS_CHAR_DEAD lipsbrother2
+			IF is_lipsbrother2_car_dead = 0
+				ADD_SCORE player 5000 
+				is_lipsbrother2_car_dead = 1
+			ENDIF
+			GOTO kill_the_player_display_message
+		ELSE
+			IF NOT IS_CHAR_HEALTH_GREATER lipsbrother2 99
+				GOTO kill_the_player_display_message
+			ENDIF
+		ENDIF
+
+		IF NOT IS_CAR_DEAD lipsbrother1_car
+			IF NOT IS_CAR_HEALTH_GREATER lipsbrother1_car 999
+				GOTO kill_the_player_display_message
+			ENDIF
+		ELSE
+			GOTO kill_the_player_display_message
+		ENDIF
+
+		IF NOT IS_CAR_DEAD lipsbrother2_car
+			IF NOT IS_CAR_HEALTH_GREATER lipsbrother2_car 999	
+				GOTO kill_the_player_display_message
+			ENDIF
+		ELSE
+			GOTO kill_the_player_display_message
+		ENDIF
+		// SCFIX: END
 
 	ENDWHILE 
 
@@ -315,6 +359,13 @@ SET_POLICE_IGNORE_PLAYER Player OFF
 SET_PLAYER_CONTROL Player ON
 SWITCH_WIDESCREEN OFF
 RESTORE_CAMERA_JUMPCUT
+
+// SCFIX: START - added label for convenience, as we trigger the chase under more circumstances
+GOTO kill_the_player
+
+kill_the_player_display_message:
+PRINT_NOW ( JM5_2 ) 5000 1 // Gosh! it's the Forelis! 
+// SCFIX: END
 
 kill_the_player:
 		

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ Replace main.scm inside data directory, but read save files compatibility note b
 - Removed unsafe code in "Cipriani's Chauffeur" operating on a stale handle to Toni's car
 - Added extra death checks for Toni in the first half of "Cipriani's Chauffeur" and interrupted Toni's "no fancy crap" line if he's hurt (for BW)
 - Fixed a 1-frame window where the player could leave the car in the initial cutscene in "Cipriani's Chauffeur" and added a timeout to that cutscene to avoid softlocks
+- Added driver health checks in "Dead Skunk in the Trunk", so Forellis start chasing the player if one of the cars is destroyed instantly or if the driver is hurt (for BW)
 
 ## Save files compatibility
 

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ All changes to the scripts were marked with `SCFIX` comment.
 
 Currently in beta status.
 
+"BW" in the list of changes refers to changes made to accommodate Fire_Head's [Breakable Windshields](https://github.com/Fire-Head/IIIBreakableWindshields) mod.
+
 ## Download SCM
 
 Get latest release here: https://github.com/Sergeanur/SCFIX-Liberty/releases
@@ -51,6 +53,9 @@ Replace main.scm inside data directory, but read save files compatibility note b
 - Re-enabled a Bobcat spawn in front of the Supa Save in Portland that was never switched on due to its script handle getting reused
 - Fixed the wanted level tutorial briefly pausing the game to load the models
 - Fixed "Arms Shortage" attempting to unload the incorrect models
+- Removed unsafe code in "Cipriani's Chauffeur" operating on a stale handle to Toni's car
+- Added extra death checks for Toni in the first half of "Cipriani's Chauffeur" and interrupted Toni's "no fancy crap" line if he's hurt (for BW)
+- Fixed a 1-frame window where the player could leave the car in the initial cutscene in "Cipriani's Chauffeur" and added a timeout to that cutscene to avoid softlocks
 
 ## Save files compatibility
 


### PR DESCRIPTION
1. Added a timeout to the initial cutscene, after 10 seconds the car will teleport to the destination.
2. Fixed a 1-frame window where the player could leave the car and softlock the mission. This was only possible on a keyboard with SilentPatch installed, as SP reduces the keyboard input latency by one frame.
3. Removed some code that presumably was intended to avoid "duplicating" Toni's car, but was unsafe as it's operating on a stale handle. No other mission in the game is concerned with duplicating like this, and it's not even any special car.
4. Added extra death checks for Toni in the first half of the cutscene. While **technically** redundant, they help Breakable Windshields.
5. In joey5, the chase now triggers if drivers are hurt, so the mission now "supports" Breakable Windshields.